### PR TITLE
Fix hostname strategy to support single hostname

### DIFF
--- a/src/Strategies/ApplicationHostnameStrategy.php
+++ b/src/Strategies/ApplicationHostnameStrategy.php
@@ -11,14 +11,10 @@ class ApplicationHostnameStrategy implements Strategy
 {
     public function isEnabled(array $params, Request $request): bool
     {
-        $hostNamesString = Arr::get($params, 'hostNames');
-
-        if (!$hostNamesString || !Str::contains($hostNamesString, ',')) {
-            return false;
-        }
+        $hostNamesString = Arr::get($params, 'hostNames', '');
 
         $hostNames = explode(',', $hostNamesString);
 
-        return in_array($request->getHost(), $hostNames);
+        return $hostNamesString && in_array($request->getHost(), $hostNames);
     }
 }

--- a/tests/Strategies/ApplicationHostnameStrategyTest.php
+++ b/tests/Strategies/ApplicationHostnameStrategyTest.php
@@ -8,6 +8,21 @@ use PHPUnit\Framework\TestCase;
 
 class ApplicationHostnameStrategyTest extends TestCase
 {
+
+    public function testWithSingleApplicationHostname()
+    {
+        $params = [
+            'hostNames' => 'example.com',
+        ];
+
+        $request = $this->createMock(Request::class);
+        $request->expects($this->once())->method('getHost')->willReturn('example.com');
+
+        $strategy = new ApplicationHostnameStrategy();
+
+        $this->assertTrue($strategy->isEnabled($params, $request));
+    }
+
     public function testWithApplicationHostname()
     {
         $params = [
@@ -39,6 +54,20 @@ class ApplicationHostnameStrategyTest extends TestCase
     public function testWithoutRemoteAddressParameters()
     {
         $params = [];
+
+        $request = $this->createMock(Request::class);
+        $request->expects($this->never())->method('getHost');
+
+        $strategy = new ApplicationHostnameStrategy();
+
+        $this->assertFalse($strategy->isEnabled($params, $request));
+    }
+
+    public function testWithEmptyRemoteAddressParameters()
+    {
+        $params = [
+            'hostNames' => '',
+        ];
 
         $request = $this->createMock(Request::class);
         $request->expects($this->never())->method('getHost');


### PR DESCRIPTION
When using hostname strategy using a single hostname the current implementation returns false statically, due to 'missing' delimiter comma. 
This fix adds tests for this scenario, too.

For interest only: Were there any reasons removing the default parameter from `Arr::get($params, 'hostNames');`?

Btw, thanks for initiating this package!