### PR TITLE
Allow passing variadic args into `Unleash->isFeatureEnabled/Disabled()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,27 @@ $feature = Feature::get('myAwesomeFeature');
 $allFeatures = Feature::all();
 ```
 
+### Dynamic Arguments
+
+If your strategy relies on dynamic data at runtime, you can pass additional arguments to the feature check functions:
+
+```php
+use \MikeFrancis\LaravelUnleash\Unleash;
+use Config;
+
+$unleash = app(Unleash::class);
+
+$allowList = config('app.allow_list');
+
+if ($unleash->isFeatureEnabled('myAwesomeFeature', $allowList)) {
+  // Congratulations, you can see this awesome feature!
+}
+
+if ($unleash->isFeatureDisabled('myAwesomeFeature', $allowList)) {
+  // Check back later for more features!
+}
+```
+
 ### Blade
 
 Blade directive for checking if a feature is **enabled**:
@@ -96,3 +117,5 @@ Or if a feature is **disabled**:
 Check back later for more features!
 @endfeatureDisabled
 ```
+
+You cannot currently use dynamic strategy arguments with Blade template directives.

--- a/config/unleash.php
+++ b/config/unleash.php
@@ -18,7 +18,8 @@ return [
 
   // Mapping of strategies used to guard features on Unleash. The default strategies are already
   // mapped below, and more strategies can be added - they just need to implement the
-  // `\MikeFrancis\LaravelUnleash\Strategies\Strategy` interface. If you would like to disable
+  // `\MikeFrancis\LaravelUnleash\Strategies\Strategy` or
+  // `\MikeFrancis\LaravelUnleash\Strategies\DynamicStrategy` interface. If you would like to disable
   // a built-in strategy, please comment it out or remove it below.
   'strategies' => [
     'applicationHostname' => \MikeFrancis\LaravelUnleash\Strategies\ApplicationHostnameStrategy::class,

--- a/src/Strategies/Contracts/DynamicStrategy.php
+++ b/src/Strategies/Contracts/DynamicStrategy.php
@@ -4,12 +4,13 @@ namespace MikeFrancis\LaravelUnleash\Strategies\Contracts;
 
 use Illuminate\Http\Request;
 
-interface Strategy
+interface DynamicStrategy
 {
     /**
      * @param array $params Strategy Configuration from Unleash
      * @param Request $request Current Request
+     * @param mixed $args An arbitrary number of arguments passed to isFeatureEnabled/Disabled
      * @return bool
      */
-    public function isEnabled(array $params, Request $request): bool;
+    public function isEnabled(array $params, Request $request, ...$args): bool;
 }

--- a/src/Unleash.php
+++ b/src/Unleash.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
+use MikeFrancis\LaravelUnleash\Strategies\Contracts\DynamicStrategy;
 use MikeFrancis\LaravelUnleash\Strategies\Contracts\Strategy;
 
 class Unleash
@@ -64,7 +65,7 @@ class Unleash
         );
     }
 
-    public function isFeatureEnabled(string $name): bool
+    public function isFeatureEnabled(string $name, ...$args): bool
     {
         $feature = $this->getFeature($name);
         $isEnabled = Arr::get($feature, 'enabled', false);
@@ -83,15 +84,19 @@ class Unleash
                 return false;
             }
 
-            $strategy = new $allStrategies[$className];
+            if (is_callable($allStrategies[$className])) {
+                $strategy = $allStrategies[$className]();
+            } else {
+                $strategy = new $allStrategies[$className];
+            }
 
-            if (!$strategy instanceof Strategy) {
-                throw new \Exception("${$className} does not implement base Strategy.");
+            if (!$strategy instanceof Strategy && !$strategy instanceof DynamicStrategy) {
+                throw new \Exception("${$className} does not implement base Strategy/DynamicStrategy.");
             }
 
             $params = Arr::get($strategyData, 'parameters', []);
 
-            if (!$strategy->isEnabled($params, $this->request)) {
+            if (!$strategy->isEnabled($params, $this->request, ...$args)) {
                 return false;
             }
         }
@@ -99,9 +104,9 @@ class Unleash
         return $isEnabled;
     }
 
-    public function isFeatureDisabled(string $name): bool
+    public function isFeatureDisabled(string $name, ...$args): bool
     {
-        return !$this->isFeatureEnabled($name);
+        return !$this->isFeatureEnabled($name, ...$args);
     }
 
     protected function fetchFeatures(): array

--- a/tests/Strategies/DynamicStrategyTest.php
+++ b/tests/Strategies/DynamicStrategyTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace MikeFrancis\LaravelUnleash\Tests\Strategies;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Contracts\Config\Repository as Config;
+use Illuminate\Http\Request;
+use MikeFrancis\LaravelUnleash\Tests\Stubs\ImplementedStrategy;
+use MikeFrancis\LaravelUnleash\Unleash;
+use PHPUnit\Framework\TestCase;
+
+class DynamicStrategyTest extends TestCase
+{
+    protected $mockHandler;
+
+    protected $client;
+
+    public function testWithoutArgs()
+    {
+        $featureName = 'someFeature';
+
+        $this->setMockHandler($featureName);
+
+        $cache = $this->createMock(Cache::class);
+
+        $request = $this->createMock(Request::class);
+
+        $strategy = $this->createMock(ImplementedStrategy::class);
+        $strategy->expects($this->exactly(2))->method('isEnabled')
+            ->with([], $request)
+            ->willReturn(true);
+
+        $config = $this->getMockConfig($strategy);
+
+        $unleash = new Unleash($this->client, $cache, $config, $request);
+
+        $this->assertTrue($unleash->isFeatureEnabled($featureName));
+        $this->assertFalse($unleash->isFeatureDisabled($featureName));
+    }
+
+    public function testWithArg()
+    {
+        $featureName = 'someFeature';
+
+        $this->setMockHandler($featureName);
+
+        $cache = $this->createMock(Cache::class);
+
+        $request = $this->createMock(Request::class);
+
+        $strategy = $this->createMock(ImplementedStrategy::class);
+        $strategy->expects($this->exactly(2))->method('isEnabled')
+            ->with([], $request, true)
+            ->willReturn(true);
+
+        $config = $this->getMockConfig($strategy);
+
+        $unleash = new Unleash($this->client, $cache, $config, $request);
+
+        $this->assertTrue($unleash->isFeatureEnabled($featureName, true));
+        $this->assertFalse($unleash->isFeatureDisabled($featureName, true));
+    }
+
+    public function testWithArgs()
+    {
+        $featureName = 'someFeature';
+
+        $this->setMockHandler($featureName);
+
+        $cache = $this->createMock(Cache::class);
+
+        $request = $this->createMock(Request::class);
+
+        $strategy = $this->createMock(ImplementedStrategy::class);
+        $strategy->expects($this->exactly(2))->method('isEnabled')
+            ->with([], $request, 'foo', 'bar', 'baz')
+            ->willReturn(true);
+
+        $config = $this->getMockConfig($strategy);
+
+        $unleash = new Unleash($this->client, $cache, $config, $request);
+
+        $this->assertTrue($unleash->isFeatureEnabled($featureName, 'foo', 'bar', 'baz'));
+        $this->assertFalse($unleash->isFeatureDisabled($featureName, 'foo', 'bar', 'baz'));
+    }
+
+    /**
+     * @param \PHPUnit\Framework\MockObject\MockObject $strategy
+     * @return Config|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected function getMockConfig(\PHPUnit\Framework\MockObject\MockObject $strategy)
+    {
+        $config = $this->createMock(Config::class);
+
+        $config->expects($this->at(0))
+            ->method('get')
+            ->with('unleash.isEnabled')
+            ->willReturn(true);
+        $config->expects($this->at(1))
+            ->method('get')
+            ->with('unleash.cache.isEnabled')
+            ->willReturn(false);
+        $config->expects($this->at(2))
+            ->method('get')
+            ->with('unleash.strategies')
+            ->willReturn(
+                [
+                    'testStrategy' => function () use ($strategy) {
+                        return $strategy;
+                    },
+                ]
+            );
+        $config->expects($this->at(3))
+            ->method('get')
+            ->with('unleash.strategies')
+            ->willReturn(
+                [
+                    'testStrategy' => function () use ($strategy) {
+                        return $strategy;
+                    },
+                ]
+            );
+        return $config;
+    }
+
+    /**
+     * @param string $featureName
+     */
+    protected function setMockHandler(string $featureName): void
+    {
+        $this->mockHandler->append(
+            new Response(
+                200,
+                [],
+                json_encode(
+                    [
+                        'features' => [
+                            [
+                                'name' => $featureName,
+                                'enabled' => true,
+                                'strategies' => [
+                                    [
+                                        'name' => 'testStrategy',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ]
+                )
+            )
+        );
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockHandler = new MockHandler();
+
+        $this->client = new Client(
+            [
+                'handler' => $this->mockHandler,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Allow passing variadic args into `Unleash->isFeatureEnabled()`/`Unleash->isFeatureDisabled()`

This change allows for more complex strategies to be employed that rely on runtime data not available in the request.

The only reason this has a `DynamicStrategy` interface, is that changing the current `Strategy` interface will be a backwards compatibility breaking change for anyone currently implementing it. If you're fine with that, I'd much prefer to just modify the existing interface.