### PR TITLE
Add support for failover cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "An Unleash client for Laravel",
     "type": "library",
     "require": {
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^6.3|^7.0",
         "illuminate/support": "^5.8|^6|^7|^8",
         "illuminate/http": "^5.8|^6|^7|^8"
     },

--- a/config/unleash.php
+++ b/config/unleash.php
@@ -11,9 +11,13 @@ return [
   'isEnabled' => env('UNLEASH_ENABLED', true),
 
   // Allow the Unleash API response to be cached.
+  // Default TTL is 15s
+  // Failover caching will use the last successful result from Unleash if it down.
+  // Failover is independent of regular caching.
   'cache' => [
-    'isEnabled' => false,
-    'ttl' => 3600,
+    'isEnabled' => env('UNLEASH_CACHE_ENABLED', false),
+    'ttl' => env('UNLEASH_CACHE_TTL', 15),
+    'failover' => env('UNLEASH_CACHE_FAILOVER', true),
   ],
 
   // Mapping of strategies used to guard features on Unleash. The default strategies are already

--- a/tests/Strategies/DynamicStrategyTest.php
+++ b/tests/Strategies/DynamicStrategyTest.php
@@ -115,6 +115,14 @@ class DynamicStrategyTest extends TestCase
             );
         $config->expects($this->at(3))
             ->method('get')
+            ->with('unleash.isEnabled')
+            ->willReturn(true);
+        $config->expects($this->at(4))
+            ->method('get')
+            ->with('unleash.cache.isEnabled')
+            ->willReturn(false);
+        $config->expects($this->at(5))
+            ->method('get')
             ->with('unleash.strategies')
             ->willReturn(
                 [

--- a/tests/UnleashTest.php
+++ b/tests/UnleashTest.php
@@ -2,6 +2,7 @@
 
 namespace MikeFrancis\LaravelUnleash\Tests;
 
+use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
@@ -12,6 +13,7 @@ use MikeFrancis\LaravelUnleash\Tests\Stubs\ImplementedStrategy;
 use MikeFrancis\LaravelUnleash\Tests\Stubs\NonImplementedStrategy;
 use MikeFrancis\LaravelUnleash\Unleash;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Exception\JsonException;
 
 class UnleashTest extends TestCase
 {
@@ -36,8 +38,25 @@ class UnleashTest extends TestCase
     {
         $featureName = 'someFeature';
 
+        $this->mockHandler->append(
+            new Response(
+                200,
+                [],
+                json_encode(
+                    [
+                        'features' => [
+                            [
+                                'name' => $featureName,
+                                'enabled' => true,
+                            ],
+                        ],
+                    ]
+                )
+            )
+        );
+
         $cache = $this->createMock(Cache::class);
-        $cache->expects($this->once())
+        $cache->expects($this->exactly(2))
             ->method('remember')
             ->willReturn(
                 [
@@ -57,12 +76,339 @@ class UnleashTest extends TestCase
             ->method('get')
             ->with('unleash.cache.isEnabled')
             ->willReturn(true);
+        $config->expects($this->at(2))
+            ->method('get')
+            ->with('unleash.cache.ttl')
+            ->willReturn(null);
+        $config->expects($this->at(3))
+            ->method('get')
+            ->with('unleash.strategies')
+            ->willReturn(
+                [
+                    'testStrategy' => ImplementedStrategy::class,
+                ]
+            );
+        $config->expects($this->at(4))
+            ->method('get')
+            ->with('unleash.isEnabled')
+            ->willReturn(true);
+        $config->expects($this->at(5))
+            ->method('get')
+            ->with('unleash.cache.isEnabled')
+            ->willReturn(true);
+        $config->expects($this->at(6))
+            ->method('get')
+            ->with('unleash.cache.ttl')
+            ->willReturn(null);
+
+        $request = $this->createMock(Request::class);
+
+        $unleash = new Unleash($this->client, $cache, $config, $request);
+        $this->assertTrue($unleash->isFeatureEnabled($featureName));
+        $this->assertTrue($unleash->isFeatureEnabled($featureName));
+    }
+
+    public function testFeaturesCacheFailoverEnabled()
+    {
+        $featureName = 'someFeature';
+
+        $this->mockHandler->append(
+            new Response(
+                200,
+                [],
+                json_encode(
+                    [
+                        'features' => [
+                            [
+                                'name' => $featureName,
+                                'enabled' => true,
+                            ],
+                        ],
+                    ]
+                )
+            )
+        );
+        $this->mockHandler->append(
+            new Response(500)
+        );
+
+        $config = $this->createMock(Config::class);
+        $cache = $this->createMock(Cache::class);
+
+        $config->expects($this->at(0))
+            ->method('get')
+            ->with('unleash.isEnabled')
+            ->willReturn(true);
+        $config->expects($this->at(1))
+            ->method('get')
+            ->with('unleash.cache.isEnabled')
+            ->willReturn(true);
+        $config->expects($this->at(2))
+            ->method('get')
+            ->with('unleash.cache.ttl')
+            ->willReturn(0.1);
+
+        $cache->expects($this->at(0))
+            ->method('remember')
+            ->willReturn(
+                [
+                    [
+                        'name' => $featureName,
+                        'enabled' => true,
+                    ],
+                ]
+            );
+        $cache->expects($this->at(1))
+            ->method('forever')
+            ->with('unleash.features.failover', [
+                [
+                    'name' => $featureName,
+                    'enabled' => true,
+                ],
+            ]);
+
+        $config->expects($this->at(3))
+            ->method('get')
+            ->with('unleash.strategies')
+            ->willReturn(
+                [
+                    'testStrategy' => ImplementedStrategy::class,
+                ]
+            );
+
+
+        // Request 2
+        $config->expects($this->at(4))
+            ->method('get')
+            ->with('unleash.isEnabled')
+            ->willReturn(true);
+        $config->expects($this->at(5))
+            ->method('get')
+            ->with('unleash.cache.isEnabled')
+            ->willReturn(true);
+        $config->expects($this->at(6))
+            ->method('get')
+            ->with('unleash.cache.ttl')
+            ->willReturn(0.1);
+
+        $cache->expects($this->at(2))
+            ->method('remember')
+            ->willThrowException(new JsonException("Expected Failure: Testing"));
+
+        $config->expects($this->at(7))
+            ->method('get')
+            ->with('unleash.cache.failover')
+            ->willReturn(true);
+        $cache->expects($this->at(3))
+            ->method('get')
+            ->with('unleash.features.failover')
+            ->willReturn(
+                [
+                    [
+                        'name' => $featureName,
+                        'enabled' => true,
+                    ],
+                ]
+            );
 
         $request = $this->createMock(Request::class);
 
         $unleash = new Unleash($this->client, $cache, $config, $request);
 
-        $this->assertTrue($unleash->isFeatureEnabled($featureName));
+        $this->assertTrue($unleash->isFeatureEnabled($featureName), "Uncached Request");
+        usleep(200);
+        $this->assertTrue($unleash->isFeatureEnabled($featureName), "Cached Request");
+    }
+
+    public function testFeaturesCacheFailoverDisabled()
+    {
+        $featureName = 'someFeature';
+
+        $this->mockHandler->append(
+            new Response(
+                200,
+                [],
+                json_encode(
+                    [
+                        'features' => [
+                            [
+                                'name' => $featureName,
+                                'enabled' => true,
+                            ],
+                        ],
+                    ]
+                )
+            )
+        );
+        $this->mockHandler->append(
+            new Response(500)
+        );
+
+        $config = $this->createMock(Config::class);
+        $cache = $this->createMock(Cache::class);
+
+        $config->expects($this->at(0))
+            ->method('get')
+            ->with('unleash.isEnabled')
+            ->willReturn(true);
+        $config->expects($this->at(1))
+            ->method('get')
+            ->with('unleash.cache.isEnabled')
+            ->willReturn(true);
+        $config->expects($this->at(2))
+            ->method('get')
+            ->with('unleash.cache.ttl')
+            ->willReturn(0.1);
+
+        $cache->expects($this->at(0))
+            ->method('remember')
+            ->willReturn(
+                [
+                    [
+                        'name' => $featureName,
+                        'enabled' => true,
+                    ],
+                ]
+            );
+        $cache->expects($this->at(1))
+            ->method('forever')
+            ->with('unleash.features.failover', [
+                [
+                    'name' => $featureName,
+                    'enabled' => true,
+                ],
+            ]);
+
+        $config->expects($this->at(3))
+            ->method('get')
+            ->with('unleash.strategies')
+            ->willReturn(
+                [
+                    'testStrategy' => ImplementedStrategy::class,
+                ]
+            );
+
+
+        // Request 2
+        $config->expects($this->at(4))
+            ->method('get')
+            ->with('unleash.isEnabled')
+            ->willReturn(true);
+        $config->expects($this->at(5))
+            ->method('get')
+            ->with('unleash.cache.isEnabled')
+            ->willReturn(true);
+        $config->expects($this->at(6))
+            ->method('get')
+            ->with('unleash.cache.ttl')
+            ->willReturn(0.1);
+
+        $cache->expects($this->at(2))
+            ->method('remember')
+            ->willThrowException(new JsonException("Expected Failure: Testing"));
+
+        $config->expects($this->at(7))
+            ->method('get')
+            ->with('unleash.cache.failover')
+            ->willReturn(false);
+
+        $request = $this->createMock(Request::class);
+
+        $unleash = new Unleash($this->client, $cache, $config, $request);
+
+        $this->assertTrue($unleash->isFeatureEnabled($featureName), "Uncached Request");
+        usleep(200);
+        $this->assertFalse($unleash->isFeatureEnabled($featureName), "Cached Request");
+    }
+
+    public function testFeaturesCacheFailoverEnabledIndependently()
+    {
+        $featureName = 'someFeature';
+
+        $this->mockHandler->append(
+            new Response(
+                200,
+                [],
+                json_encode(
+                    [
+                        'features' => [
+                            [
+                                'name' => $featureName,
+                                'enabled' => true,
+                            ],
+                        ],
+                    ]
+                )
+            )
+        );
+        $this->mockHandler->append(
+            new Response(500)
+        );
+
+        $config = $this->createMock(Config::class);
+        $cache = $this->createMock(Cache::class);
+
+        $config->expects($this->at(0))
+            ->method('get')
+            ->with('unleash.isEnabled')
+            ->willReturn(true);
+        $config->expects($this->at(1))
+            ->method('get')
+            ->with('unleash.cache.isEnabled')
+            ->willReturn(false);
+
+        $cache->expects($this->at(0))
+            ->method('forever')
+            ->with('unleash.features.failover', [
+                [
+                    'name' => $featureName,
+                    'enabled' => true,
+                ],
+            ]);
+
+        $config->expects($this->at(2))
+            ->method('get')
+            ->with('unleash.strategies')
+            ->willReturn(
+                [
+                    'testStrategy' => ImplementedStrategy::class,
+                ]
+            );
+
+
+        // Request 2
+        $config->expects($this->at(3))
+            ->method('get')
+            ->with('unleash.isEnabled')
+            ->willReturn(true);
+        $config->expects($this->at(4))
+            ->method('get')
+            ->with('unleash.cache.isEnabled')
+            ->willReturn(false);
+        $config->expects($this->at(5))
+            ->method('get')
+            ->with('unleash.cache.failover')
+            ->willReturn(true);
+
+        $cache->expects($this->at(1))
+            ->method('get')
+            ->with('unleash.features.failover')
+            ->willReturn(
+                [
+                    [
+                        'name' => $featureName,
+                        'enabled' => true,
+                    ],
+                ]
+            );
+
+        $request = $this->createMock(Request::class);
+
+        $unleash = new Unleash($this->client, $cache, $config, $request);
+        $this->assertTrue($unleash->isFeatureEnabled($featureName), "Uncached Request");
+
+        $unleash = new Unleash($this->client, $cache, $config, $request);
+        $this->assertTrue($unleash->isFeatureEnabled($featureName), "Cached Request");
     }
 
     public function testFeatureDetectionCanBeDisabled()
@@ -304,7 +650,7 @@ class UnleashTest extends TestCase
 
         try {
             $unleash->isFeatureEnabled($featureName);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->assertNotEmpty($e);
         }
     }


### PR DESCRIPTION
The failover cache will ensure that the last successful set of features fetched from Unleash are always returned if the unleash server is down.

- Changes cache TTL default to 15s, the standard default
- Add unleash.cache.failover option that will pull the last successful result from the cache
  - This setting is independent of regular caching
  - The cache is always stored, to allow enabling the feature during a failure incidence
- This change also moves the requests for features out of the constructor
  - Possible to use in Facades
  - Still "cached" for the lifetime of the Unleash object