### PR TITLE
Add Middleware feature.enabled, feature.disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,45 @@ Check back later for more features!
 ```
 
 You cannot currently use dynamic strategy arguments with Blade template directives.
+
+### Middleware
+
+This package includes middleware that will deny routes depending on whether a feature is enabled or not.
+
+To use the middle, add the following to your `app/Http/Kernel.php`:
+
+```php
+protected $routeMiddleware = [
+    // other middleware
+    'feature.enabled' => \MikeFrancis\LaravelUnleash\Middleware\FeatureEnabled::class,
+    'feature.disabled' => \MikeFrancis\LaravelUnleash\Middleware\FeatureDisabled::class,
+];
+```
+
+You can then use the middleware in your routes:
+
+```php
+Route::get('/new-feature-path', function () {
+    //
+})->middleware('feature.enabled:myAwesomeFeature');
+
+Route::get('/terrible-legacy-path', function () {
+    //
+})->middleware('feature.disabled:myAwesomeFeature');
+```
+
+or in your controllers like so:
+
+```php
+class ExampleController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('feature.enabled:myAwesomeFeature');
+        // or
+        $this->middleware('feature.disabled:myAwesomeFeature');
+    }
+}
+```
+
+You cannot currently use dynamic strategy arguments with Middleware.

--- a/src/Middleware/FeatureDisabled.php
+++ b/src/Middleware/FeatureDisabled.php
@@ -1,11 +1,14 @@
 <?php
+
 namespace MikeFrancis\LaravelUnleash\Middleware;
 
+use Closure;
+use Illuminate\Http\Request;
 use MikeFrancis\LaravelUnleash\Facades\Feature;
 
 class FeatureDisabled
 {
-    public function handle($request, \Closure $next, $featureName)
+    public function handle(Request $request, Closure $next, string $featureName)
     {
         if (Feature::enabled($featureName)) {
             abort(404);

--- a/src/Middleware/FeatureDisabled.php
+++ b/src/Middleware/FeatureDisabled.php
@@ -1,0 +1,16 @@
+<?php
+namespace MikeFrancis\LaravelUnleash\Middleware;
+
+use MikeFrancis\LaravelUnleash\Facades\Feature;
+
+class FeatureDisabled
+{
+    public function handle($request, \Closure $next, $featureName)
+    {
+        if (Feature::enabled($featureName)) {
+            abort(404);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Middleware/FeatureEnabled.php
+++ b/src/Middleware/FeatureEnabled.php
@@ -1,0 +1,16 @@
+<?php
+namespace MikeFrancis\LaravelUnleash\Middleware;
+
+use MikeFrancis\LaravelUnleash\Facades\Feature;
+
+class FeatureEnabled
+{
+    public function handle($request, \Closure $next, $featureName)
+    {
+        if (!Feature::enabled($featureName)) {
+            abort(404);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Middleware/FeatureEnabled.php
+++ b/src/Middleware/FeatureEnabled.php
@@ -1,11 +1,14 @@
 <?php
+
 namespace MikeFrancis\LaravelUnleash\Middleware;
 
+use Closure;
+use Illuminate\Http\Request;
 use MikeFrancis\LaravelUnleash\Facades\Feature;
 
 class FeatureEnabled
 {
-    public function handle($request, \Closure $next, $featureName)
+    public function handle(Request $request, Closure $next, string $featureName)
     {
         if (!Feature::enabled($featureName)) {
             abort(404);


### PR DESCRIPTION
This builds on #25 and adds the ability to easily protect routes or controllers using middleware.

From the README:

### Middleware

This package includes middleware that will deny routes depending on whether a feature is enabled or not.

To use the middle, add the following to your `app/Http/Kernel.php`:

```php
protected $routeMiddleware = [
    // other middleware
    'feature.enabled' => \MikeFrancis\LaravelUnleash\Middleware\FeatureEnabled::class,
    'feature.disabled' => \MikeFrancis\LaravelUnleash\Middleware\FeatureDisabled::class,
];
```

You can then use the middleware in your routes:

```php
Route::get('/new-feature-path', function () {
    //
})->middleware('feature.enabled:myAwesomeFeature');

Route::get('/terrible-legacy-path', function () {
    //
})->middleware('feature.disabled:myAwesomeFeature');
```

or in your controllers like so:

```php
class ExampleController extends Controller
{
    public function __construct()
    {
        $this->middleware('feature.enabled:myAwesomeFeature');
        // or
        $this->middleware('feature.disabled:myAwesomeFeature');
    }
}
```

You cannot currently use dynamic strategy arguments with Middleware.