### PR TITLE
Make endpoint and request options configurable.

### DIFF
--- a/config/unleash.php
+++ b/config/unleash.php
@@ -5,6 +5,13 @@ return [
   // This should be the base URL, do not include /api or anything else.
   'url' => env('UNLEASH_URL'),
 
+  // Endpoint for accessing feature flags, on the Unleash server.
+  'features_endpoint' => env('UNLEASH_FEATURES_ENDPOINT', '/api/client/features'),
+
+  // Any options that are required for your request to the Unleash server.
+  // e.g. some servers may require headers with authentication information.
+  'request_options' => [],
+
   // Globally control whether Unleash is enabled or disabled.
   // If not enabled, no API requests will be made and all "enabled" checks will return `false` and
   // "disabled" checks will return `true`.

--- a/config/unleash.php
+++ b/config/unleash.php
@@ -18,7 +18,8 @@ return [
   ],
 
   // Endpoint for accessing the feature flags, on your Unleash server.
-  // The default is /api/client/features ; your Unleash server may use a different endpoint e.g. if it houses flags for multiple projects.
+  // The default is /api/client/features;
+  // your Unleash server may use a different endpoint e.g. if it houses flags for multiple projects.
   'featuresEndpoint' => env('UNLEASH_FEATURES_ENDPOINT', '/api/client/features'),
 
   // Globally control whether Unleash is enabled or disabled.

--- a/config/unleash.php
+++ b/config/unleash.php
@@ -1,13 +1,12 @@
 <?php
 
 return [
+  // URL of the Unleash server.
+  // This should be the base URL, do not include /api or anything else.
+  'url' => env('UNLEASH_URL'),
 
-  // Default settings for requests to your Unleash server.
-  'requestDefaults' => [
-    // URL of the Unleash server.
-    // This should be the base URL, do not include /api or anything else.
-    'base_uri' => env('UNLEASH_URL'),
-
+  // Other default settings for requests to your Unleash server.
+  'otherRequestDefaults' => [
     // Any other defaults for the request can be added here.
     // e.g. your Unleash server may require headers like these.
     //

--- a/config/unleash.php
+++ b/config/unleash.php
@@ -1,16 +1,25 @@
 <?php
 
 return [
-  // URL of the Unleash server.
-  // This should be the base URL, do not include /api or anything else.
-  'url' => env('UNLEASH_URL'),
 
-  // Endpoint for accessing feature flags, on the Unleash server.
+  // Default settings for requests to your Unleash server.
+  'requestDefaults' => [
+    // URL of the Unleash server.
+    // This should be the base URL, do not include /api or anything else.
+    'base_uri' => env('UNLEASH_URL'),
+
+    // Any other defaults for the request can be added here.
+    // e.g. your Unleash server may require headers like these.
+    //
+    // 'headers' => [
+    //   'UNLEASH-APPNAME' => env('UNLEASH_APPNAME', env('APP_ENV')),
+    //   'UNLEASH-INSTANCEID' => env('UNLEASH_INSTANCEID'),
+    // ],
+  ],
+
+  // Endpoint for accessing the feature flags, on your Unleash server.
+  // The default is /api/client/features ; your Unleash server may use a different endpoint e.g. if it houses flags for multiple projects.
   'featuresEndpoint' => env('UNLEASH_FEATURES_ENDPOINT', '/api/client/features'),
-
-  // Any options that are required for your request to the Unleash server.
-  // e.g. some servers may require headers with authentication information.
-  'requestOptions' => [],
 
   // Globally control whether Unleash is enabled or disabled.
   // If not enabled, no API requests will be made and all "enabled" checks will return `false` and

--- a/config/unleash.php
+++ b/config/unleash.php
@@ -6,11 +6,11 @@ return [
   'url' => env('UNLEASH_URL'),
 
   // Endpoint for accessing feature flags, on the Unleash server.
-  'features_endpoint' => env('UNLEASH_FEATURES_ENDPOINT', '/api/client/features'),
+  'featuresEndpoint' => env('UNLEASH_FEATURES_ENDPOINT', '/api/client/features'),
 
   // Any options that are required for your request to the Unleash server.
   // e.g. some servers may require headers with authentication information.
-  'request_options' => [],
+  'requestOptions' => [],
 
   // Globally control whether Unleash is enabled or disabled.
   // If not enabled, no API requests will be made and all "enabled" checks will return `false` and

--- a/src/Client.php
+++ b/src/Client.php
@@ -10,9 +10,7 @@ class Client extends GuzzleClient
     public function __construct(Config $config)
     {
         parent::__construct(
-            [
-                'base_uri' => $config->get('unleash.url'),
-            ]
+            $config->get('unleash.requestDefaults')
         );
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -10,7 +10,10 @@ class Client extends GuzzleClient
     public function __construct(Config $config)
     {
         parent::__construct(
-            $config->get('unleash.requestDefaults')
+            array_merge(
+                ['base_uri' => $config->get('unleash.url')],
+                $config->get('unleash.otherRequestDefaults')
+            )
         );
     }
 }

--- a/src/Unleash.php
+++ b/src/Unleash.php
@@ -127,7 +127,7 @@ class Unleash
 
     protected function fetchFeatures(): array
     {
-        $response = $this->client->get($this->getFeaturesApiUrl(), $this->getRequestOptions());
+        $response = $this->client->get($this->getFeaturesEndpoint(), $this->getRequestOptions());
 
         try {
             $data = json_decode((string)$response->getBody(), true, 512, \JSON_BIGINT_AS_STRING);
@@ -137,15 +137,15 @@ class Unleash
 
         return $this->formatResponse($data);
     }
-    
-    protected function getFeaturesApiUrl(): string
+
+    protected function getFeaturesEndpoint(): string
     {
-        return '/api/client/features';
+        return $this->config->get('unleash.features_endpoint');
     }
 
     protected function getRequestOptions(): array
     {
-        return [];
+        return $this->config->get('unleash.request_options');
     }
 
     protected function formatResponse($data): array

--- a/src/Unleash.php
+++ b/src/Unleash.php
@@ -140,12 +140,12 @@ class Unleash
 
     protected function getFeaturesEndpoint(): string
     {
-        return $this->config->get('unleash.features_endpoint');
+        return $this->config->get('unleash.featuresEndpoint');
     }
 
     protected function getRequestOptions(): array
     {
-        return $this->config->get('unleash.request_options');
+        return $this->config->get('unleash.requestOptions');
     }
 
     protected function formatResponse($data): array

--- a/src/Unleash.php
+++ b/src/Unleash.php
@@ -127,7 +127,7 @@ class Unleash
 
     protected function fetchFeatures(): array
     {
-        $response = $this->client->get($this->getFeaturesEndpoint(), $this->getRequestOptions());
+        $response = $this->client->get($this->config->get('unleash.featuresEndpoint'));
 
         try {
             $data = json_decode((string)$response->getBody(), true, 512, \JSON_BIGINT_AS_STRING);
@@ -136,16 +136,6 @@ class Unleash
         }
 
         return $this->formatResponse($data);
-    }
-
-    protected function getFeaturesEndpoint(): string
-    {
-        return $this->config->get('unleash.featuresEndpoint');
-    }
-
-    protected function getRequestOptions(): array
-    {
-        return $this->config->get('unleash.requestOptions');
     }
 
     protected function formatResponse($data): array

--- a/tests/Strategies/DynamicStrategyTest.php
+++ b/tests/Strategies/DynamicStrategyTest.php
@@ -105,6 +105,14 @@ class DynamicStrategyTest extends TestCase
             ->willReturn(false);
         $config->expects($this->at(2))
             ->method('get')
+            ->with('unleash.features_endpoint')
+            ->willReturn('/api/client/features');
+        $config->expects($this->at(3))
+            ->method('get')
+            ->with('unleash.request_options')
+            ->willReturn([]);
+        $config->expects($this->at(4))
+            ->method('get')
             ->with('unleash.strategies')
             ->willReturn(
                 [
@@ -113,15 +121,15 @@ class DynamicStrategyTest extends TestCase
                     },
                 ]
             );
-        $config->expects($this->at(3))
+        $config->expects($this->at(5))
             ->method('get')
             ->with('unleash.isEnabled')
             ->willReturn(true);
-        $config->expects($this->at(4))
+        $config->expects($this->at(6))
             ->method('get')
             ->with('unleash.cache.isEnabled')
             ->willReturn(false);
-        $config->expects($this->at(5))
+        $config->expects($this->at(7))
             ->method('get')
             ->with('unleash.strategies')
             ->willReturn(

--- a/tests/Strategies/DynamicStrategyTest.php
+++ b/tests/Strategies/DynamicStrategyTest.php
@@ -105,11 +105,11 @@ class DynamicStrategyTest extends TestCase
             ->willReturn(false);
         $config->expects($this->at(2))
             ->method('get')
-            ->with('unleash.features_endpoint')
+            ->with('unleash.featuresEndpoint')
             ->willReturn('/api/client/features');
         $config->expects($this->at(3))
             ->method('get')
-            ->with('unleash.request_options')
+            ->with('unleash.requestOptions')
             ->willReturn([]);
         $config->expects($this->at(4))
             ->method('get')

--- a/tests/Strategies/DynamicStrategyTest.php
+++ b/tests/Strategies/DynamicStrategyTest.php
@@ -88,7 +88,7 @@ class DynamicStrategyTest extends TestCase
     }
 
     /**
-     * @param \PHPUnit\Framework\MockObject\MockObject $strategy
+     * @param  \PHPUnit\Framework\MockObject\MockObject $strategy
      * @return Config|\PHPUnit\Framework\MockObject\MockObject
      */
     protected function getMockConfig(\PHPUnit\Framework\MockObject\MockObject $strategy)
@@ -109,10 +109,6 @@ class DynamicStrategyTest extends TestCase
             ->willReturn('/api/client/features');
         $config->expects($this->at(3))
             ->method('get')
-            ->with('unleash.requestOptions')
-            ->willReturn([]);
-        $config->expects($this->at(4))
-            ->method('get')
             ->with('unleash.strategies')
             ->willReturn(
                 [
@@ -121,15 +117,15 @@ class DynamicStrategyTest extends TestCase
                     },
                 ]
             );
-        $config->expects($this->at(5))
+        $config->expects($this->at(4))
             ->method('get')
             ->with('unleash.isEnabled')
             ->willReturn(true);
-        $config->expects($this->at(6))
+        $config->expects($this->at(5))
             ->method('get')
             ->with('unleash.cache.isEnabled')
             ->willReturn(false);
-        $config->expects($this->at(7))
+        $config->expects($this->at(6))
             ->method('get')
             ->with('unleash.strategies')
             ->willReturn(

--- a/tests/UnleashTest.php
+++ b/tests/UnleashTest.php
@@ -360,10 +360,6 @@ class UnleashTest extends TestCase
             ->method('get')
             ->with('unleash.featuresEndpoint')
             ->willReturn('/api/client/features');
-        $config->expects($this->at(3))
-            ->method('get')
-            ->with('unleash.requestOptions')
-            ->willReturn([]);
 
         $cache->expects($this->at(0))
             ->method('forever')
@@ -374,7 +370,7 @@ class UnleashTest extends TestCase
                 ],
             ]);
 
-        $config->expects($this->at(4))
+        $config->expects($this->at(3))
             ->method('get')
             ->with('unleash.strategies')
             ->willReturn(
@@ -385,23 +381,19 @@ class UnleashTest extends TestCase
 
 
         // Request 2
-        $config->expects($this->at(5))
+        $config->expects($this->at(4))
             ->method('get')
             ->with('unleash.isEnabled')
             ->willReturn(true);
-        $config->expects($this->at(6))
+        $config->expects($this->at(5))
             ->method('get')
             ->with('unleash.cache.isEnabled')
             ->willReturn(false);
-        $config->expects($this->at(7))
+        $config->expects($this->at(6))
             ->method('get')
             ->with('unleash.featuresEndpoint')
             ->willReturn('/api/client/features');
-        $config->expects($this->at(8))
-            ->method('get')
-            ->with('unleash.requestOptions')
-            ->willReturn([]);
-        $config->expects($this->at(9))
+        $config->expects($this->at(7))
             ->method('get')
             ->with('unleash.cache.failover')
             ->willReturn(true);
@@ -464,10 +456,6 @@ class UnleashTest extends TestCase
             ->method('get')
             ->with('unleash.featuresEndpoint')
             ->willReturn('/api/client/features');
-        $config->expects($this->at(3))
-            ->method('get')
-            ->with('unleash.requestOptions')
-            ->willReturn([]);
 
         $request = $this->createMock(Request::class);
 
@@ -512,10 +500,6 @@ class UnleashTest extends TestCase
             ->method('get')
             ->with('unleash.featuresEndpoint')
             ->willReturn('/api/client/features');
-        $config->expects($this->at(3))
-            ->method('get')
-            ->with('unleash.requestOptions')
-            ->willReturn([]);
 
         $request = $this->createMock(Request::class);
 
@@ -566,10 +550,6 @@ class UnleashTest extends TestCase
             ->with('unleash.featuresEndpoint')
             ->willReturn('/api/client/features');
         $config->expects($this->at(3))
-            ->method('get')
-            ->with('unleash.requestOptions')
-            ->willReturn([]);
-        $config->expects($this->at(4))
             ->method('get')
             ->with('unleash.strategies')
             ->willReturn(
@@ -628,10 +608,6 @@ class UnleashTest extends TestCase
             ->willReturn('/api/client/features');
         $config->expects($this->at(3))
             ->method('get')
-            ->with('unleash.requestOptions')
-            ->willReturn([]);
-        $config->expects($this->at(4))
-            ->method('get')
             ->with('unleash.strategies')
             ->willReturn(
                 [
@@ -689,11 +665,6 @@ class UnleashTest extends TestCase
             ->willReturn('/api/client/features');
         $config->expects($this->at(3))
             ->method('get')
-            ->with('unleash.requestOptions')
-            ->willReturn([]);
-
-        $config->expects($this->at(4))
-            ->method('get')
             ->with('unleash.strategies')
             ->willReturn(
                 [
@@ -748,10 +719,6 @@ class UnleashTest extends TestCase
             ->method('get')
             ->with('unleash.featuresEndpoint')
             ->willReturn('/api/client/features');
-        $config->expects($this->at(3))
-            ->method('get')
-            ->with('unleash.requestOptions')
-            ->willReturn([]);
 
         $request = $this->createMock(Request::class);
 

--- a/tests/UnleashTest.php
+++ b/tests/UnleashTest.php
@@ -358,11 +358,11 @@ class UnleashTest extends TestCase
             ->willReturn(false);
         $config->expects($this->at(2))
             ->method('get')
-            ->with('unleash.features_endpoint')
+            ->with('unleash.featuresEndpoint')
             ->willReturn('/api/client/features');
         $config->expects($this->at(3))
             ->method('get')
-            ->with('unleash.request_options')
+            ->with('unleash.requestOptions')
             ->willReturn([]);
 
         $cache->expects($this->at(0))
@@ -395,11 +395,11 @@ class UnleashTest extends TestCase
             ->willReturn(false);
         $config->expects($this->at(7))
             ->method('get')
-            ->with('unleash.features_endpoint')
+            ->with('unleash.featuresEndpoint')
             ->willReturn('/api/client/features');
         $config->expects($this->at(8))
             ->method('get')
-            ->with('unleash.request_options')
+            ->with('unleash.requestOptions')
             ->willReturn([]);
         $config->expects($this->at(9))
             ->method('get')
@@ -462,11 +462,11 @@ class UnleashTest extends TestCase
             ->with('unleash.cache.isEnabled')->willReturn(false);
         $config->expects($this->at(2))
             ->method('get')
-            ->with('unleash.features_endpoint')
+            ->with('unleash.featuresEndpoint')
             ->willReturn('/api/client/features');
         $config->expects($this->at(3))
             ->method('get')
-            ->with('unleash.request_options')
+            ->with('unleash.requestOptions')
             ->willReturn([]);
 
         $request = $this->createMock(Request::class);
@@ -510,11 +510,11 @@ class UnleashTest extends TestCase
             ->willReturn(false);
         $config->expects($this->at(2))
             ->method('get')
-            ->with('unleash.features_endpoint')
+            ->with('unleash.featuresEndpoint')
             ->willReturn('/api/client/features');
         $config->expects($this->at(3))
             ->method('get')
-            ->with('unleash.request_options')
+            ->with('unleash.requestOptions')
             ->willReturn([]);
 
         $request = $this->createMock(Request::class);
@@ -563,11 +563,11 @@ class UnleashTest extends TestCase
             ->willReturn(false);
         $config->expects($this->at(2))
             ->method('get')
-            ->with('unleash.features_endpoint')
+            ->with('unleash.featuresEndpoint')
             ->willReturn('/api/client/features');
         $config->expects($this->at(3))
             ->method('get')
-            ->with('unleash.request_options')
+            ->with('unleash.requestOptions')
             ->willReturn([]);
         $config->expects($this->at(4))
             ->method('get')
@@ -624,11 +624,11 @@ class UnleashTest extends TestCase
             ->willReturn(false);
         $config->expects($this->at(2))
             ->method('get')
-            ->with('unleash.features_endpoint')
+            ->with('unleash.featuresEndpoint')
             ->willReturn('/api/client/features');
         $config->expects($this->at(3))
             ->method('get')
-            ->with('unleash.request_options')
+            ->with('unleash.requestOptions')
             ->willReturn([]);
         $config->expects($this->at(4))
             ->method('get')
@@ -685,11 +685,11 @@ class UnleashTest extends TestCase
             ->willReturn(false);
         $config->expects($this->at(2))
             ->method('get')
-            ->with('unleash.features_endpoint')
+            ->with('unleash.featuresEndpoint')
             ->willReturn('/api/client/features');
         $config->expects($this->at(3))
             ->method('get')
-            ->with('unleash.request_options')
+            ->with('unleash.requestOptions')
             ->willReturn([]);
 
         $config->expects($this->at(4))
@@ -746,11 +746,11 @@ class UnleashTest extends TestCase
             ->willReturn(false);
         $config->expects($this->at(2))
             ->method('get')
-            ->with('unleash.features_endpoint')
+            ->with('unleash.featuresEndpoint')
             ->willReturn('/api/client/features');
         $config->expects($this->at(3))
             ->method('get')
-            ->with('unleash.request_options')
+            ->with('unleash.requestOptions')
             ->willReturn([]);
 
         $request = $this->createMock(Request::class);

--- a/tests/UnleashTest.php
+++ b/tests/UnleashTest.php
@@ -356,6 +356,14 @@ class UnleashTest extends TestCase
             ->method('get')
             ->with('unleash.cache.isEnabled')
             ->willReturn(false);
+        $config->expects($this->at(2))
+            ->method('get')
+            ->with('unleash.features_endpoint')
+            ->willReturn('/api/client/features');
+        $config->expects($this->at(3))
+            ->method('get')
+            ->with('unleash.request_options')
+            ->willReturn([]);
 
         $cache->expects($this->at(0))
             ->method('forever')
@@ -366,7 +374,7 @@ class UnleashTest extends TestCase
                 ],
             ]);
 
-        $config->expects($this->at(2))
+        $config->expects($this->at(4))
             ->method('get')
             ->with('unleash.strategies')
             ->willReturn(
@@ -377,15 +385,23 @@ class UnleashTest extends TestCase
 
 
         // Request 2
-        $config->expects($this->at(3))
+        $config->expects($this->at(5))
             ->method('get')
             ->with('unleash.isEnabled')
             ->willReturn(true);
-        $config->expects($this->at(4))
+        $config->expects($this->at(6))
             ->method('get')
             ->with('unleash.cache.isEnabled')
             ->willReturn(false);
-        $config->expects($this->at(5))
+        $config->expects($this->at(7))
+            ->method('get')
+            ->with('unleash.features_endpoint')
+            ->willReturn('/api/client/features');
+        $config->expects($this->at(8))
+            ->method('get')
+            ->with('unleash.request_options')
+            ->willReturn([]);
+        $config->expects($this->at(9))
             ->method('get')
             ->with('unleash.cache.failover')
             ->willReturn(true);
@@ -444,6 +460,14 @@ class UnleashTest extends TestCase
         $config->expects($this->at(1))
             ->method('get')
             ->with('unleash.cache.isEnabled')->willReturn(false);
+        $config->expects($this->at(2))
+            ->method('get')
+            ->with('unleash.features_endpoint')
+            ->willReturn('/api/client/features');
+        $config->expects($this->at(3))
+            ->method('get')
+            ->with('unleash.request_options')
+            ->willReturn([]);
 
         $request = $this->createMock(Request::class);
 
@@ -484,6 +508,14 @@ class UnleashTest extends TestCase
             ->method('get')
             ->with('unleash.cache.isEnabled')
             ->willReturn(false);
+        $config->expects($this->at(2))
+            ->method('get')
+            ->with('unleash.features_endpoint')
+            ->willReturn('/api/client/features');
+        $config->expects($this->at(3))
+            ->method('get')
+            ->with('unleash.request_options')
+            ->willReturn([]);
 
         $request = $this->createMock(Request::class);
 
@@ -530,6 +562,14 @@ class UnleashTest extends TestCase
             ->with('unleash.cache.isEnabled')
             ->willReturn(false);
         $config->expects($this->at(2))
+            ->method('get')
+            ->with('unleash.features_endpoint')
+            ->willReturn('/api/client/features');
+        $config->expects($this->at(3))
+            ->method('get')
+            ->with('unleash.request_options')
+            ->willReturn([]);
+        $config->expects($this->at(4))
             ->method('get')
             ->with('unleash.strategies')
             ->willReturn(
@@ -584,6 +624,14 @@ class UnleashTest extends TestCase
             ->willReturn(false);
         $config->expects($this->at(2))
             ->method('get')
+            ->with('unleash.features_endpoint')
+            ->willReturn('/api/client/features');
+        $config->expects($this->at(3))
+            ->method('get')
+            ->with('unleash.request_options')
+            ->willReturn([]);
+        $config->expects($this->at(4))
+            ->method('get')
             ->with('unleash.strategies')
             ->willReturn(
                 [
@@ -637,6 +685,15 @@ class UnleashTest extends TestCase
             ->willReturn(false);
         $config->expects($this->at(2))
             ->method('get')
+            ->with('unleash.features_endpoint')
+            ->willReturn('/api/client/features');
+        $config->expects($this->at(3))
+            ->method('get')
+            ->with('unleash.request_options')
+            ->willReturn([]);
+
+        $config->expects($this->at(4))
+            ->method('get')
             ->with('unleash.strategies')
             ->willReturn(
                 [
@@ -687,6 +744,14 @@ class UnleashTest extends TestCase
             ->method('get')
             ->with('unleash.cache.isEnabled')
             ->willReturn(false);
+        $config->expects($this->at(2))
+            ->method('get')
+            ->with('unleash.features_endpoint')
+            ->willReturn('/api/client/features');
+        $config->expects($this->at(3))
+            ->method('get')
+            ->with('unleash.request_options')
+            ->willReturn([]);
 
         $request = $this->createMock(Request::class);
 


### PR DESCRIPTION
These changes allow the client to be used with other Unleash servers.

My use case is GitLab: I need to be able to specify the feature flags endpoint for a particular project, and I need to pass two headers to identify the environment and the instance.

So in my own `.env` I have:

```
UNLEASH_URL="https://{our GitLab server}"
UNLEASH_FEATURES_ENDPOINT="/api/v4/feature_flags/unleash/{my project id}/features"
```

And in my `config/unleash.php`:

```
  'request_options' => [
    'headers' => [
        'UNLEASH-APPNAME' => 'local',
        'UNLEASH-INSTANCEID' => '{my instance id}',
    ]
  ],
```