### PR TITLE
Bind GuzzleHttpClient as default client for Unleash.

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,6 +4,9 @@ namespace MikeFrancis\LaravelUnleash;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider as IlluminateServiceProvider;
+use MikeFrancis\LaravelUnleash\Unleash;
+use MikeFrancis\LaravelUnleash\Client;
+use GuzzleHttp\ClientInterface;
 
 class ServiceProvider extends IlluminateServiceProvider
 {
@@ -15,9 +18,9 @@ class ServiceProvider extends IlluminateServiceProvider
     public function register()
     {
         $this->mergeConfigFrom($this->getConfigPath(), 'unleash');
+        $this->app ->when(Unleash::class)->needs(ClientInterface::class)->give(Client::class);
         $this->app->singleton('unleash', function ($app) {
-            $client = $app->make(Client::class);
-            return $app->make(Unleash::class, ['client' => $client]);
+            return $app->make(Unleash::class);
         });
     }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -18,7 +18,7 @@ class ServiceProvider extends IlluminateServiceProvider
     public function register()
     {
         $this->mergeConfigFrom($this->getConfigPath(), 'unleash');
-        $this->app ->when(Unleash::class)->needs(ClientInterface::class)->give(Client::class);
+        $this->app->when(Unleash::class)->needs(ClientInterface::class)->give(Client::class);
         $this->app->singleton('unleash', function ($app) {
             return $app->make(Unleash::class);
         });


### PR DESCRIPTION
https://github.com/mikefrancis/laravel-unleash/issues/16#issuecomment-734755863

(Finally :) )

From the suggestion by https://github.com/gsmofgsm in that thread.

This update provides `GuzzleHttp\ClientInterface` as the default client for Unleash.

In particular, it allows the use of the Facade without having to first bind Guzzle into the service container.