### PR TITLE
Fix isFeatureEnabled returns false when multiple strategies are configured

### DIFF
--- a/src/Unleash.php
+++ b/src/Unleash.php
@@ -81,22 +81,24 @@ class Unleash
         foreach ($strategies as $strategyData) {
             $className = $strategyData['name'];
 
-            if (array_key_exists($className, $allStrategies)) {
-                if (is_callable($allStrategies[$className])) {
-                    $strategy = $allStrategies[$className]();
-                } else {
-                    $strategy = new $allStrategies[$className];
-                }
-    
-                if (!$strategy instanceof Strategy && !$strategy instanceof DynamicStrategy) {
-                    throw new \Exception("${$className} does not implement base Strategy/DynamicStrategy.");
-                }
-    
-                $params = Arr::get($strategyData, 'parameters', []);
-    
-                if ($strategy->isEnabled($params, $this->request, ...$args)) {
-                    return true;
-                }
+            if (!array_key_exists($className, $allStrategies)) {
+                continue;
+            }
+
+            if (is_callable($allStrategies[$className])) {
+                $strategy = $allStrategies[$className]();
+            } else {
+                $strategy = new $allStrategies[$className];
+            }
+
+            if (!$strategy instanceof Strategy && !$strategy instanceof DynamicStrategy) {
+                throw new \Exception("${$className} does not implement base Strategy/DynamicStrategy.");
+            }
+
+            $params = Arr::get($strategyData, 'parameters', []);
+
+            if ($strategy->isEnabled($params, $this->request, ...$args)) {
+                return true;
             }
         }
 

--- a/src/Unleash.php
+++ b/src/Unleash.php
@@ -74,7 +74,7 @@ class Unleash
         $strategies = Arr::get($feature, 'strategies', []);
         $allStrategies = $this->config->get('unleash.strategies', []);
 
-        if (count($strategies) == 0) {
+        if (count($strategies) === 0) {
             return $isEnabled;
         }
 

--- a/src/Unleash.php
+++ b/src/Unleash.php
@@ -74,7 +74,7 @@ class Unleash
         $strategies = Arr::get($feature, 'strategies', []);
         $allStrategies = $this->config->get('unleash.strategies', []);
 
-        if(count($strategies) == 0) {
+        if (count($strategies) == 0) {
             return $isEnabled;
         }
 
@@ -82,7 +82,6 @@ class Unleash
             $className = $strategyData['name'];
 
             if (array_key_exists($className, $allStrategies)) {
-                
                 if (is_callable($allStrategies[$className])) {
                     $strategy = $allStrategies[$className]();
                 } else {
@@ -98,7 +97,6 @@ class Unleash
                 if ($strategy->isEnabled($params, $this->request, ...$args)) {
                     return true;
                 }
-                
             }
         }
 

--- a/tests/Stubs/ImplementedStrategyThatDoesNotMatch.php
+++ b/tests/Stubs/ImplementedStrategyThatDoesNotMatch.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace MikeFrancis\LaravelUnleash\Tests\Stubs;
+
+use Illuminate\Http\Request;
+use MikeFrancis\LaravelUnleash\Strategies\Contracts\Strategy;
+
+class ImplementedStrategyThatDoesNotMatch implements Strategy
+{
+    public function isEnabled(array $params, Request $request): bool
+    {
+        return false;
+    }
+}

--- a/tests/Stubs/ImplementedStrategyThatIsDisabled.php
+++ b/tests/Stubs/ImplementedStrategyThatIsDisabled.php
@@ -5,7 +5,7 @@ namespace MikeFrancis\LaravelUnleash\Tests\Stubs;
 use Illuminate\Http\Request;
 use MikeFrancis\LaravelUnleash\Strategies\Contracts\Strategy;
 
-class ImplementedStrategyThatDoesNotMatch implements Strategy
+class ImplementedStrategyThatIsDisabled implements Strategy
 {
     public function isEnabled(array $params, Request $request): bool
     {

--- a/tests/UnleashTest.php
+++ b/tests/UnleashTest.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Http\Request;
 use MikeFrancis\LaravelUnleash\Tests\Stubs\ImplementedStrategy;
+use MikeFrancis\LaravelUnleash\Tests\Stubs\ImplementedStrategyThatIsDisabled;
 use MikeFrancis\LaravelUnleash\Tests\Stubs\NonImplementedStrategy;
 use MikeFrancis\LaravelUnleash\Unleash;
 use PHPUnit\Framework\TestCase;
@@ -581,11 +582,11 @@ class UnleashTest extends TestCase
                                 'enabled' => true,
                                 'strategies' => [
                                     [
-                                        'name' => 'testStrategy',
+                                        'name' => 'testStrategyThatIsDisabled',
                                     ],
                                     [
-                                        'name' => 'testStrategyThatDoesNotMatch',
-                                    ],
+                                        'name' => 'testStrategy',
+                                    ]
                                 ],
                             ],
                         ],
@@ -617,7 +618,7 @@ class UnleashTest extends TestCase
                     'testStrategy' => ImplementedStrategy::class,
                 ],
                 [
-                    'testStrategyThatDoesNotMatch' => ImplementedStrategyThatDoesNotMatch::class,
+                    'testStrategyThatIsDisabled' => ImplementedStrategyThatIsDisabled::class,
                 ]
             );
 

--- a/tests/UnleashTest.php
+++ b/tests/UnleashTest.php
@@ -789,5 +789,4 @@ class UnleashTest extends TestCase
 
         $this->assertTrue($unleash->isFeatureDisabled($featureName));
     }
-
 }


### PR DESCRIPTION
Hi there, firstly thanks for a great package. I am currently implementing Unleash to manage feature access in my application.

I have come across an issue when a feature has been configured with multiple different activation strategies. In my app, there are multiple scenarios under which I'd like a user to gain access to a feature e.g:

- The user is on a specific plan
- The user has a specific id
- App environment matches specific value etc

What I am experiencing is that if any of these strategy evaluations fail, then the function returns the feature is not available.

From the unleash documentation (https://docs.getunleash.io/user_guide/important-concepts)

> Activation strategies​
Feature toggles can have multiple activation strategies. An activation strategy will only run when a feature toggle is enabled and provides a way to control WHO will get access to the feature.
Activation strategies compound, and every single strategy will be evaluated. If any one of them returns true, the user will receive access to the feature.

I have found by modifying the isFeatureEnabled function, I can achieve the expected behaviour according to the unleash docs. I have also added a new test which now passes.