### PR TITLE
Update unleash.php

### DIFF
--- a/config/unleash.php
+++ b/config/unleash.php
@@ -7,6 +7,7 @@ return [
 
   // Other default settings for requests to your Unleash server.
   'otherRequestDefaults' => [
+      'timeout' => 1,
     // Any other defaults for the request can be added here.
     // e.g. your Unleash server may require headers like these.
     //


### PR DESCRIPTION
during a recent gitlab outage, we noticed that requests were hanging in our fpm queue

a normal requests to the (gitlab) unleash api takes 200-300ms, i expect other unleash api's to not be slower