### PR TITLE
fix deprecation message

### DIFF
--- a/src/Unleash.php
+++ b/src/Unleash.php
@@ -92,7 +92,7 @@ class Unleash
             }
 
             if (!$strategy instanceof Strategy && !$strategy instanceof DynamicStrategy) {
-                throw new \Exception("${$className} does not implement base Strategy/DynamicStrategy.");
+                throw new \Exception($className . ' does not implement base Strategy/DynamicStrategy.');
             }
 
             $params = Arr::get($strategyData, 'parameters', []);


### PR DESCRIPTION
Fix: Deprecated: Using ${expr} (variable variables) in strings is deprecated