### PR TITLE
Set to only save failover if config is active

### DIFF
--- a/src/Unleash.php
+++ b/src/Unleash.php
@@ -37,8 +37,9 @@ class Unleash
         try {
             $features = $this->getCachedFeatures();
 
-            // Always store the failover cache, in case it is turned on during failure scenarios.
-            $this->cache->forever('unleash.features.failover', $features);
+            if ($this->config->get('unleash.cache.failover') === true) {
+                $this->cache->forever('unleash.features.failover', $features);
+            }
 
             return $features;
         } catch (TransferException | JsonException $e) {


### PR DESCRIPTION
I noticed that always saving the failover for each get Feature can be costly and hurt the perfomance of the app

Screenshot of the profiler i use in my app: 
![image](https://github.com/laravel-unleash/laravel-unleash/assets/18106308/f46d3f04-32e6-4cf6-adb6-95ba1b7ca0fa)
