### PR TITLE
fix 2 performance issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ phpunit.xml
 
 composer.phar
 composer.lock
+
+.php-cs-fixer.cache

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
     "type": "library",
     "require": {
         "guzzlehttp/guzzle": "^6.3|^7.0",
-        "illuminate/support": "^5.8|^6|^7|^8|^9|^10.0",
-        "illuminate/http": "^5.8|^6|^7|^8|^9|^10.0",
-        "illuminate/contracts": "^5.8|^6|^7|^8|^9|^10.0"
+        "illuminate/support": "^5.8|^6|^7|^8|^9|^10|^11",
+        "illuminate/http": "^5.8|^6|^7|^8|^9|^10|^11",
+        "illuminate/contracts": "^5.8|^6|^7|^8|^9|^10|^11"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.10",

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,10 @@
     "description": "An Unleash client for Laravel",
     "type": "library",
     "require": {
-        "guzzlehttp/guzzle": "^6.3|^7.0",
-        "illuminate/support": "^5.8|^6|^7|^8|^9|^10|^11|^12",
-        "illuminate/http": "^5.8|^6|^7|^8|^9|^10|^11|^12",
-        "illuminate/contracts": "^5.8|^6|^7|^8|^9|^10|^11|^12"
+        "guzzlehttp/guzzle": "*",
+        "illuminate/support": "*",
+        "illuminate/http": "*",
+        "illuminate/contracts": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.10",

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
     "type": "library",
     "require": {
         "guzzlehttp/guzzle": "^6.3|^7.0",
-        "illuminate/support": "^5.8|^6|^7|^8|^9|^10|^11",
-        "illuminate/http": "^5.8|^6|^7|^8|^9|^10|^11",
-        "illuminate/contracts": "^5.8|^6|^7|^8|^9|^10|^11"
+        "illuminate/support": "^5.8|^6|^7|^8|^9|^10|^11|^12",
+        "illuminate/http": "^5.8|^6|^7|^8|^9|^10|^11|^12",
+        "illuminate/contracts": "^5.8|^6|^7|^8|^9|^10|^11|^12"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.10",

--- a/src/Facades/Feature.php
+++ b/src/Facades/Feature.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MikeFrancis\LaravelUnleash\Facades;
 
 use Illuminate\Support\Facades\Facade;

--- a/src/Facades/Unleash.php
+++ b/src/Facades/Unleash.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MikeFrancis\LaravelUnleash\Facades;
 
 use Illuminate\Support\Facades\Facade;

--- a/src/Middleware/RefreshFeatures.php
+++ b/src/Middleware/RefreshFeatures.php
@@ -17,7 +17,7 @@ class RefreshFeatures
 
     public function terminate()
     {
-        $unleash = app('unleash');
+        $unleash = app(Unleash::class);
         if (!$unleash instanceof Unleash) {
             return;
         }

--- a/src/Middleware/RefreshFeatures.php
+++ b/src/Middleware/RefreshFeatures.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace MikeFrancis\LaravelUnleash\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use MikeFrancis\LaravelUnleash\Unleash;
+
+class RefreshFeatures
+{
+    public float $ttlThresholdFactor = 0.75; // when ttl has reached 75%, refresh the cache
+
+    public function handle(Request $request, Closure $next)
+    {
+        return $next($request);
+    }
+
+    public function terminate()
+    {
+        $unleash = app('unleash');
+        if (!$unleash instanceof Unleash) {
+            return;
+        }
+        if (time() + ($unleash->getCacheTTL() * $this->ttlThresholdFactor) > $unleash->getExpires()) {
+            $unleash->refreshCache();
+        }
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,8 +4,6 @@ namespace MikeFrancis\LaravelUnleash;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider as IlluminateServiceProvider;
-use MikeFrancis\LaravelUnleash\Unleash;
-use MikeFrancis\LaravelUnleash\Client;
 use GuzzleHttp\ClientInterface;
 
 class ServiceProvider extends IlluminateServiceProvider
@@ -42,6 +40,7 @@ class ServiceProvider extends IlluminateServiceProvider
             function (string $feature) {
                 $client = app(Client::class);
                 $unleash = app(Unleash::class, ['client' => $client]);
+                assert($unleash instanceof Unleash);
 
                 return $unleash->isFeatureEnabled($feature);
             }
@@ -52,6 +51,7 @@ class ServiceProvider extends IlluminateServiceProvider
             function (string $feature) {
                 $client = app(Client::class);
                 $unleash = app(Unleash::class, ['client' => $client]);
+                assert($unleash instanceof Unleash);
 
                 return !$unleash->isFeatureEnabled($feature);
             }
@@ -60,8 +60,6 @@ class ServiceProvider extends IlluminateServiceProvider
 
     /**
      * Get the path to the config.
-     *
-     * @return string
      */
     private function getConfigPath(): string
     {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -24,10 +24,8 @@ class ServiceProvider extends IlluminateServiceProvider
 
     /**
      * Perform post-registration booting of services.
-     *
-     * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         $this->publishes(
             [

--- a/src/Strategies/ApplicationHostnameStrategy.php
+++ b/src/Strategies/ApplicationHostnameStrategy.php
@@ -4,7 +4,6 @@ namespace MikeFrancis\LaravelUnleash\Strategies;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use MikeFrancis\LaravelUnleash\Strategies\Contracts\Strategy;
 
 class ApplicationHostnameStrategy implements Strategy

--- a/src/Strategies/Contracts/DynamicStrategy.php
+++ b/src/Strategies/Contracts/DynamicStrategy.php
@@ -9,8 +9,7 @@ interface DynamicStrategy
     /**
      * @param array $params Strategy Configuration from Unleash
      * @param Request $request Current Request
-     * @param mixed $args An arbitrary number of arguments passed to isFeatureEnabled/Disabled
-     * @return bool
+     * @param mixed ...$args An arbitrary number of arguments passed to isFeatureEnabled/Disabled
      */
     public function isEnabled(array $params, Request $request, ...$args): bool;
 }

--- a/src/Strategies/Contracts/DynamicStrategy.php
+++ b/src/Strategies/Contracts/DynamicStrategy.php
@@ -11,5 +11,5 @@ interface DynamicStrategy
      * @param Request $request Current Request
      * @param mixed ...$args An arbitrary number of arguments passed to isFeatureEnabled/Disabled
      */
-    public function isEnabled(array $params, Request $request, ...$args): bool;
+    public function isEnabled(array $params, Request $request, mixed ...$args): bool;
 }

--- a/src/Strategies/Contracts/Strategy.php
+++ b/src/Strategies/Contracts/Strategy.php
@@ -9,7 +9,6 @@ interface Strategy
     /**
      * @param array $params Strategy Configuration from Unleash
      * @param Request $request Current Request
-     * @return bool
      */
     public function isEnabled(array $params, Request $request): bool;
 }

--- a/src/Strategies/DefaultStrategy.php
+++ b/src/Strategies/DefaultStrategy.php
@@ -7,6 +7,10 @@ use MikeFrancis\LaravelUnleash\Strategies\Contracts\Strategy;
 
 class DefaultStrategy implements Strategy
 {
+    /**
+     * @unused-param $params
+     * @unused-param $request
+     */
     public function isEnabled(array $params, Request $request): bool
     {
         return true;

--- a/src/Unleash.php
+++ b/src/Unleash.php
@@ -2,7 +2,6 @@
 
 namespace MikeFrancis\LaravelUnleash;
 
-use GuzzleHttp\Client;
 use GuzzleHttp\Exception\TransferException;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Contracts\Config\Repository as Config;

--- a/src/Unleash.php
+++ b/src/Unleash.php
@@ -58,11 +58,11 @@ class Unleash
         return $this->features;
     }
 
-    public function getFeature(string $name)
+    public function getFeature(string $name): array
     {
         $features = $this->getFeatures();
 
-        return Arr::first(
+        return (array) Arr::first(
             $features,
             function (array $unleashFeature) use ($name) {
                 return $name === $unleashFeature['name'];

--- a/src/Unleash.php
+++ b/src/Unleash.php
@@ -40,6 +40,7 @@ class Unleash
             return [];
         }
 
+        $data = [];
         try {
             if ($this->config->get('unleash.cache.isEnabled')) {
                 $data = $this->getCachedFeatures();

--- a/tests/Strategies/ApplicationHostnameStrategyTest.php
+++ b/tests/Strategies/ApplicationHostnameStrategyTest.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\TestCase;
 
 class ApplicationHostnameStrategyTest extends TestCase
 {
-
     public function testWithSingleApplicationHostname()
     {
         $params = [


### PR DESCRIPTION
I've noticed a performance penalty when calling getFeatures() multiple times in one request.
This is because on every call, it has to read and write the features from (redis) cache.
I've also taken into account that some processes might be running for a long time, thats why i'm saving/checking the time()

Secondly i've added a middleware that can run during shutdown.
It will update the unleash cache when it's about to expire.
This way the next user doesn't get the "penalty" at the start of their request.